### PR TITLE
Bump ralph version to publish in NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lendi/ralph",
   "description": "ralph is a CLI tool that automates security incident response",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT",
   "files": [
     "lib"


### PR DESCRIPTION
The previous build had two issues:
- NPM token wasn't recognized
- version wasn't bumped. 

The NPM token has already been updated. Now, bumping this version should fix this error:
```
error Couldn't publish package: "https://registry.npmjs.org/@lendi%2fralph: You cannot publish over the previously published versions: 1.0.3."
```